### PR TITLE
Add GLMakie to dependencies list

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -26,6 +26,7 @@ julia = "1.7"
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 CairoMakie = "13f3f980-e62b-5c42-98c6-ff1f3baf88f0"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+GLMakie = "e9467ef8-e4e7-5192-8a1a-b1aee30e663a"
 
 [targets]
 test = ["Aqua", "CairoMakie", "Test"]


### PR DESCRIPTION
The first line in the [readme's demo](https://github.com/agdestein/IncompressibleNavierStokes.jl#demo) crashes due to `GLMakie` not being shipped with the package. This can be frustrating for future potential users. I suggest installing it directly via the `Project.toml` as an extra package