### PR TITLE
fix missing docs link

### DIFF
--- a/docs/src/.vitepress/config.mts
+++ b/docs/src/.vitepress/config.mts
@@ -83,6 +83,7 @@ export default defineConfig({
               { text: 'Pressure solvers', link: '/manual/pressure' },
               { text: 'Solver', link: '/manual/solver' },
               { text: 'Utils', link: '/manual/utils' },
+              { text: 'SciML', link: '/manual/sciml' },
               { text: 'Neural closure models', link: '/manual/closure' },
             ],
           },


### PR DESCRIPTION
The link to the sciml page in the documentation (introduced in #116) was missing

## Checklist

- [x] I have added my name to the [`CITATION.cff` file](https://github.com/agdestein/IncompressibleNavierStokes.jl/blob/main/CITATION.cff).
