### PR TITLE
BugFix: Replace map with for loop

### DIFF
--- a/lib/PaperDC/src/train.jl
+++ b/lib/PaperDC/src/train.jl
@@ -11,11 +11,12 @@ createdata(; params, seeds, outdir, taskid) =
             @info "Skipping seed $(repr(seed)) for task $taskid"
             continue
         end
-        filenames = map(Iterators.product(params.nles, params.filters)) do nles, Φ
+        filenames = []
+        for (nles, Φ) in Iterators.product(params.nles, params.filters)
             f = getdatafile(outdir, nles, Φ, seed)
             datadir = dirname(f)
             ispath(datadir) || mkpath(datadir)
-            f
+            push!(filenames, f)
         end
         data = create_les_data(; params..., rng = Xoshiro(seed), filenames)
         @info(


### PR DESCRIPTION
This inner function from PaperDC fails on my machine:
https://github.com/agdestein/IncompressibleNavierStokes.jl/blob/e5dd0d9613326367927480e0b0f21fe3f4ad008f/lib/PaperDC/src/train.jl#L14-L19
so I have replaced it with a for loop.

## Checklist

- [x] I have added my name to the [`CITATION.cff` file](https://github.com/agdestein/IncompressibleNavierStokes.jl/blob/main/CITATION.cff).
