### PR TITLE
Updated broken link to WaterLily KA operator implementation post

### DIFF
--- a/docs/src/manual/operators.md
+++ b/docs/src/manual/operators.md
@@ -9,7 +9,7 @@ All discrete operators are built using
 and Cartesian indices, similar to
 [WaterLily.jl](https://github.com/weymouth/WaterLily.jl/).
 This allows for dimension- and backend-agnostic code. See this
-[blog post](https://b-fg.github.io/2023/05/07/waterlily-on-gpu.html)
+[blog post](https://b-fg.github.io/research/2023-07-05-waterlily-on-gpu.html)
 for how to write kernels. IncompressibleNavierStokes previously relied on
 assembling sparse operators to perform the same operations. While being very
 efficient and also compatible with CUDA (CUSPARSE), storing these matrices in

--- a/src/operators.jl
+++ b/src/operators.jl
@@ -41,7 +41,7 @@ Cartesian index unit vector in `D = 2` or `D = 3` dimensions.
 Calling `Offset(D)(α)` returns a Cartesian index with `1` in the dimension `α` and zeros
 elsewhere.
 
-See <https://b-fg.github.io/2023/05/07/waterlily-on-gpu.html>
+See <https://b-fg.github.io/research/2023-07-05-waterlily-on-gpu.html>
 for writing kernel loops using Cartesian indices.
 """
 struct Offset{D} end


### PR DESCRIPTION
I was checking these docs because I want to update the current docs for WaterLily, and I must say the documentation here is AMAZING. Might try to use something similar in the future.
And doing so I noted a broken link to my post on KA and WaterLily, so this is an update.

## Checklist

- [ ] I have added my name to the [`CITATION.cff` file](https://github.com/agdestein/IncompressibleNavierStokes.jl/blob/main/CITATION.cff).
