### PR TITLE
Fix small bugs across solvers, extensions, and tests

### DIFF
--- a/ext/AMGXExt.jl
+++ b/ext/AMGXExt.jl
@@ -49,12 +49,12 @@ function IncompressibleNavierStokes.close_amgx(stuff)
     AMGX.finalize()
 end
 
-function IncompressibleNavierStokes.psolver_cg_AMGX(setup; stuff, kwargs...)
-    (; x, Np, Ip, boundary_conditions, backend) = grid
+function IncompressibleNavierStokes.psolver_cg_AMGX(setup; stuff)
+    (; x, Np, Ip, boundary_conditions, backend) = setup
     T = eltype(x[1])
     L = laplacian_mat(setup)
-    isdefinite = true
-    #any(bc -> bc[1] isa PressureBC || bc[2] isa PressureBC, boundary_conditions)
+    isdefinite =
+        any(bc -> bc[1] isa PressureBC || bc[2] isa PressureBC, boundary_conditions.u)
     if isdefinite
         # No extra DOF
         ftemp = fill!(similar(x[1], prod(Np)), 0)

--- a/ext/CUDSSExt.jl
+++ b/ext/CUDSSExt.jl
@@ -22,7 +22,7 @@ function IncompressibleNavierStokes.psolver_direct(::CuArray, setup)
     T = eltype(x[1])
     L = laplacian_mat(setup)
     isdefinite =
-        any(bc -> bc[1] isa PressureBC || bc[2] isa PressureBC, boundary_conditions)
+        any(bc -> bc[1] isa PressureBC || bc[2] isa PressureBC, boundary_conditions.u)
     if isdefinite
         # No extra DOF
         ftemp = fill!(similar(x[1], prod(Np)), 0)

--- a/ext/EnzymeCoreExt.jl
+++ b/ext/EnzymeCoreExt.jl
@@ -8,7 +8,7 @@ using IncompressibleNavierStokes.KernelAbstractions.Extras.LoopInfo: @unroll
 using EnzymeCore
 using EnzymeCore.EnzymeRules
 
-INS = IncompressibleNavierStokes
+const INS = IncompressibleNavierStokes
 
 # Wrap a function to return `nothing`, because Enzyme can not handle vector return values.
 INS.enzyme_wrap(
@@ -373,7 +373,7 @@ function EnzymeRules.reverse(
     u::Duplicated,
     setup::Const,
 )
-    @error "convection_diffusion_temp Enzyme-AD not yet implemented"
+    error("convection_diffusion_temp Enzyme-AD not yet implemented")
 end
 
 function EnzymeRules.augmented_primal(
@@ -387,7 +387,7 @@ function EnzymeRules.augmented_primal(
     t::Const,
     setup::Const,
 )
-    @error "navierstokes! Enzyme-AD not yet implemented"
+    error("navierstokes! Enzyme-AD not yet implemented")
 end
 
 function EnzymeRules.reverse(
@@ -401,7 +401,7 @@ function EnzymeRules.reverse(
     t::Const,
     setup::Const,
 )
-    @error "navierstokes! Enzyme-AD not yet implemented"
+    error("navierstokes! Enzyme-AD not yet implemented")
 end
 # COV_EXCL_STOP
 

--- a/ext/MakieExt.jl
+++ b/ext/MakieExt.jl
@@ -152,7 +152,7 @@ function fieldplot(
             lims = get_lims(f)
         elseif type ∈ (contour, contourf)
             if ≈(extrema(f)...; rtol = 1e-10)
-                μ = mean(f)
+                μ = sum(f) / length(f)
                 a = μ - 1
                 b = μ + 1
                 f[1] += 1
@@ -206,7 +206,7 @@ function fieldplot(
     state;
     setup,
     psolver = nothing,
-    fieldname = :eig2field,
+    fieldname = :qcrit,
     alpha = convert(eltype(setup.x[1]), 0.1),
     # isorange = convert(eltype(setup.x[1]), 0.5),
     equal_axis = true,

--- a/src/eddyviscosity.jl
+++ b/src/eddyviscosity.jl
@@ -295,12 +295,14 @@ end
 @kernel function eddy_viscosity_kernel!(O::CartesianIndex{3}, e::QR, visc, G_split, grid)
     I = @index(Global, Cartesian)
     I = I + O
+    T = eltype(G_split.xx)
     G = collocate_tensor(G_split, I)
     d = gridsize_vol(grid, I)
     S = (G + G') / 2
     QS = tr(S * S) / 2
     RS = tr(S * S * S) / 3
-    visc[I] = (e.C * d)^2 * abs(RS) / QS
+    # Guard against 0 / 0 = NaN for zero strain
+    visc[I] = (e.C * d)^2 * abs(RS) / (QS + eps(T))
 end
 
 @kernel function eddy_viscosity_kernel!(

--- a/src/matrices.jl
+++ b/src/matrices.jl
@@ -164,8 +164,7 @@ function bc_p_mat(::PeriodicBC, setup, β, isright = false)
     sparse(i, j, v, prod(N), prod(N))
 end
 
-bc_temp_mat(bc::PeriodicBC, setup, β, isright = false) =
-    apply_bc_p_mat(bc, setup, β, isright)
+bc_temp_mat(bc::PeriodicBC, setup, β, isright = false) = bc_p_mat(bc, setup, β, isright)
 
 function bc_u_mat(::DirichletBC, setup, β, isright = false)
     (; dimension, N, Iu, x) = setup

--- a/src/solver.jl
+++ b/src/solver.jl
@@ -102,18 +102,19 @@ function solve_unsteady(;
                 # Change timestep based on operators
                 Δt = cfl * propose_timestep(force!, stepper.state, setup, params)
                 Δt = isnothing(Δt_min) ? Δt : max(Δt, Δt_min)
+                if Δt < 1e-10 || Δt > 100 || isnan(Δt)
+                    @warn "Proposed time step $Δt is out of bounds. Stopping simulation."
+                    break
+                end
             end
 
             # Make sure not to step past `t_end`
-            Δt = min(Δt, tend - stepper.t)
-
-            if Δt < 1e-10 || Δt > 100 || isnan(Δt)
-                @warn "Proposed time step $Δt is out of bounds. Stopping simulation."
-                break
-            end
+            # (keep `Δt` itself unclipped, it is reused until the next adaptation)
+            Δt_step = min(Δt, tend - stepper.t)
 
             # Perform a single time step with the time integration method
-            stepper = timestep!(method, force!, stepper, Δt; params, ode_cache, force_cache)
+            stepper =
+                timestep!(method, force!, stepper, Δt_step; params, ode_cache, force_cache)
 
             # Process iteration results with each processor
             state[] = get_state(stepper)

--- a/test/timesteppers.jl
+++ b/test/timesteppers.jl
@@ -4,7 +4,7 @@
     bc = PeriodicBC(), PeriodicBC()
     setup = Setup(; x = (ax, ax), boundary_conditions = (; u = (bc, bc), temp = (bc, bc)))
     psolver = default_psolver(setup)
-    u = random_field(setup, psolver)
+    u = random_field(setup; psolver)
     temp = randn!(scalarfield(setup))
     temp = apply_bc_temp(temp, 0.0, setup)
     Δt = 0.1


### PR DESCRIPTION
First of a series of cleanup PRs based on a full code review. Nine small, independent bug fixes:

- **`src/matrices.jl`**: `bc_temp_mat` for `PeriodicBC` called nonexistent `apply_bc_p_mat` (`UndefVarError` for any periodic temperature BC matrix) — forward to `bc_p_mat`.
- **`ext/AMGXExt.jl`**: `psolver_cg_AMGX` destructured undefined `grid` instead of `setup` (errored immediately); restored the `PressureBC`-based `isdefinite` check (was hardcoded `true`); dropped silently ignored `kwargs...`.
- **`ext/CUDSSExt.jl`**: `isdefinite` iterated `boundary_conditions` (the named tuple) instead of `boundary_conditions.u`, so it was always `false` — `PressureBC` setups on GPU got the singular-augmented system `[L e; e' 0]`, silently changing the pressure solution.
- **`ext/EnzymeCoreExt.jl`**: not-implemented rules used `@error` (logs, then returns an invalid value to Enzyme) instead of `error`; made the `INS` alias `const`.
- **`ext/MakieExt.jl`**: `mean` was never imported (`UndefVarError` in the near-constant contour branch); 3D `fieldplot` defaulted to unsupported `:eig2field` → `:qcrit`.
- **`src/eddyviscosity.jl`**: QR model produced `NaN` (`0/0`) for zero strain; denominator guarded with `eps(T)` like WALE.
- **`src/solver.jl`**: the adaptive-Δt sanity check ran *after* clipping to `tend - t`, so finishing a run within round-off of `tend` spuriously warned "time step out of bounds, stopping". The check now runs on the proposed Δt, and the clip no longer overwrites the reusable Δt (which used to persist a tiny step into later iterations when `n_adapt_Δt > 1`).
- **`test/timesteppers.jl`**: `random_field(setup, psolver)` passed the psolver as the positional *time* argument; now passed as keyword.

Verified: full test suite passes locally (434 pass, 7 pre-existing broken); each fix also exercised by hand (periodic `bc_temp_mat` matches the kernel BC, adaptive solve reaches `tend` without warning, QR viscosity finite for zero strain).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XY72uPCQCasBnrzEMg2jQG