### PR TITLE
Fix Enzyme example in differentiability docs

### DIFF
--- a/docs/src/manual/differentiability.md
+++ b/docs/src/manual/differentiability.md
@@ -129,11 +129,14 @@ Now, we call the `autodiff` function from Enzyme:
 Enzyme.autodiff(Enzyme.Reverse, f!, Duplicated(dudt,ddudt), Duplicated(u,du), Const(params_ref), Const(t))
 ```
 Since we have passed a `Duplicated` object, the gradient of `u` is stored in `du`.
+Note that the output seed `ddudt` is consumed in the process: Enzyme zeroes it
+during the reverse pass.
 
-Finally, we can also compare its value with the one obtained by Zygote differentiating the out-of-place (non-mutating) version of the right-hand side:
+Finally, we can also compare its value with the one obtained by Zygote differentiating the out-of-place (non-mutating) version of the right-hand side. We seed the Zygote pullback with a fresh copy of the original seed (a vector of ones):
 
 ```@example Differentiability
 f = create_right_hand_side(setup, psolver)
 _, zpull = Zygote.pullback(f, u, (; viscosity), 0.0);
-@assert zpull(dudt)[1] == du
+w = one.(dudt); # The same seed values that ddudt started with
+@assert zpull(w)[1] ≈ du
 ```


### PR DESCRIPTION
The Documentation build on `main` fails since #186:

```
failed to run `@example` block in docs/src/manual/differentiability.md:135-139
AssertionError: (zpull(dudt))[1] == du
```

The example asserted `zpull(dudt)[1] == du`, seeding the Zygote pullback with `dudt` — which at that point holds the *primal* right-hand-side output. That identity only held under the old buggy Enzyme reverse rule, which multiplied the seed by the primal output. With the corrected rule, the correct comparison seeds Zygote with the same cotangent that Enzyme was seeded with (a vector of ones; note Enzyme zeroes the seed `ddudt` during the reverse pass, so a fresh copy is used).

Verified the fixed example end-to-end against the current main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XY72uPCQCasBnrzEMg2jQG