### PR TITLE
Fix typos failing the Spell Check CI job

### DIFF
--- a/_typos.toml
+++ b/_typos.toml
@@ -1,6 +1,0 @@
-[default.extend-identifiers]
-FOM = "FOM"
-
-[default.extend-words]
-# "FOM" = full-order model (reduced-order modeling terminology)
-fom = "fom"

--- a/_typos.toml
+++ b/_typos.toml
@@ -1,3 +1,6 @@
+[default.extend-identifiers]
+FOM = "FOM"
+
 [default.extend-words]
 # "FOM" = full-order model (reduced-order modeling terminology)
 fom = "fom"

--- a/_typos.toml
+++ b/_typos.toml
@@ -1,0 +1,3 @@
+[default.extend-words]
+# "FOM" = full-order model (reduced-order modeling terminology)
+fom = "fom"

--- a/examples/DipolePOD.jl
+++ b/examples/DipolePOD.jl
@@ -1,6 +1,6 @@
 # # Two-dimensional dipole
 #
-# This example uses thet setup from the paper
+# This example uses the setup from the paper
 # > Study of a staggered fourth‐order compact scheme for unsteady incompressible viscous flows 
 # > Knikker, 2009, International Journal for Numerical Methods in Fluids
 # > <https://onlinelibrary.wiley.com/doi/10.1002/fld.1854>
@@ -28,7 +28,7 @@ import IncompressibleNavierStokes as NS
 #
 # We first define all actions in functions, and run them later.
 # This makes it convenient to comment out the slow running function calls later and
-# just `include("filname.jl")` to run everything.
+# just `include("filename.jl")` to run everything.
 # It also keeps the namespace clean and avoids too many global variables.
 
 # Define all parameters here for convenience

--- a/typos.toml
+++ b/typos.toml
@@ -1,2 +1,6 @@
 [files]
 extend-exclude = ["docs/references.bib"]
+
+[default.extend-words]
+# "FOM" = full-order model (reduced-order modeling terminology)
+FOM = "FOM"


### PR DESCRIPTION
The Spell Check job runs on every PR and currently fails on all of them due to pre-existing typos in `examples/DipolePOD.jl` ("thet", "filname") and the intentional acronym "FOM" (full-order model). This fixes the two real typos and whitelists FOM via a new `_typos.toml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XY72uPCQCasBnrzEMg2jQG