### PR TITLE
Add pullbacks for scalar coefficients (viscosity, conductivity, gravity)

### DIFF
--- a/src/operators.jl
+++ b/src/operators.jl
@@ -526,15 +526,17 @@ end
 "Compute diffusive term (differentiable version)."
 diffusion(u, setup, viscosity) = diffusion!(zero.(u), u, setup, viscosity)
 
-ChainRulesCore.rrule(::typeof(diffusion), u, setup, viscosity) = (
-    diffusion(u, setup, viscosity),
-    φ -> (
-        NoTangent(),
-        diffusion_adjoint!(zero(u), φ, setup, viscosity),
-        NoTangent(),
-        NoTangent(),
-    ),
-)
+function ChainRulesCore.rrule(::typeof(diffusion), u, setup, viscosity)
+    d = diffusion(u, setup, viscosity)
+    function diffusion_pullback(φ)
+        φ = unthunk(φ)
+        ubar = diffusion_adjoint!(zero(u), φ, setup, viscosity)
+        # The diffusive term is linear in the scalar viscosity
+        viscositybar = dot(diffusion(u, setup, one(viscosity)), φ)
+        (NoTangent(), ubar, NoTangent(), viscositybar)
+    end
+    (d, diffusion_pullback)
+end
 
 """
 Compute diffusive term (in-place version).
@@ -650,7 +652,11 @@ function ChainRulesCore.rrule(
             setup,
             conductivity,
         )
-        (NoTangent(), ubar, tempbar, NoTangent(), NoTangent())
+        # The convective part vanishes at zero velocity, and the diffusive
+        # part is linear in the scalar conductivity
+        conductivitybar =
+            dot(convection_diffusion_temp(zero(u), temp, setup, one(conductivity)), φ)
+        (NoTangent(), ubar, tempbar, NoTangent(), conductivitybar)
     end
     (c, convection_diffusion_temp_pullback)
 end
@@ -781,9 +787,12 @@ applygravity(temp, setup, gdir, gravity) =
 ChainRulesCore.rrule(::typeof(applygravity), temp, setup, gdir, gravity) =
     applygravity(temp, setup, gdir, gravity),
     function gravity_pullback(φbar)
+        φbar = unthunk(φbar)
         tempbar = zero(temp)
         applygravity_adjoint!(tempbar, φbar, setup, gdir, gravity)
-        NoTangent(), tempbar, NoTangent(), NoTangent(), NoTangent()
+        # The gravity term is linear in the scalar gravity
+        gravitybar = dot(applygravity(temp, setup, gdir, one(gravity)), φbar)
+        NoTangent(), tempbar, NoTangent(), NoTangent(), gravitybar
     end
 
 """

--- a/test/chainrules.jl
+++ b/test/chainrules.jl
@@ -140,13 +140,13 @@ end
         diffusion,
         Case.D2.u,
         Case.D2.setup ⊢ NoTangent(),
-        Case.D2.params.viscosity ⊢ NoTangent(),
+        Case.D2.params.viscosity,
     )
     test_rrule_named(
         diffusion,
         Case.D3.u,
         Case.D3.setup ⊢ NoTangent(),
-        Case.D2.params.viscosity ⊢ NoTangent(),
+        Case.D3.params.viscosity,
     )
 end
 
@@ -160,7 +160,7 @@ end
             temp,
             setup ⊢ NoTangent(),
             Case.D2.params.gdir ⊢ NoTangent(),
-            Case.D2.params.gravity ⊢ NoTangent(),
+            Case.D2.params.gravity,
         )
 
         @test_broken 1 == 2 # Just to identify location for broken rrule test
@@ -172,7 +172,7 @@ end
             u,
             temp,
             setup ⊢ NoTangent(),
-            case.params.conductivity ⊢ NoTangent(),
+            case.params.conductivity,
         )
     end
 end
@@ -185,7 +185,7 @@ end
     for case in (Case.D2, Case.D3)
         (; u, temp, setup, params) = case
         (; viscosity, conductivity, gdir, gravity) = params
-        loss(u, temp) = begin
+        loss(u, temp, viscosity, conductivity, gravity) = begin
             f = boussinesq(
                 (; u, temp),
                 zero(eltype(u));
@@ -199,15 +199,52 @@ end
             )
             sum(abs2, f.u) + sum(abs2, f.temp)
         end
-        gu, gtemp = Zygote.gradient(loss, u, temp)
+        gu, gtemp, gvisc, gcond, ggrav =
+            Zygote.gradient(loss, u, temp, viscosity, conductivity, gravity)
 
         # Compare with central finite differences in random directions
         h = cbrt(eps(eltype(u)))
         vu = randn!(rng, zero(u))
         vtemp = randn!(rng, zero(temp))
-        dloss_u = (loss(u .+ h .* vu, temp) - loss(u .- h .* vu, temp)) / 2h
-        dloss_temp = (loss(u, temp .+ h .* vtemp) - loss(u, temp .- h .* vtemp)) / 2h
+        l(u, temp; visc = viscosity, cond = conductivity, grav = gravity) =
+            loss(u, temp, visc, cond, grav)
+        dloss_u = (l(u .+ h .* vu, temp) - l(u .- h .* vu, temp)) / 2h
+        dloss_temp = (l(u, temp .+ h .* vtemp) - l(u, temp .- h .* vtemp)) / 2h
+        dloss_visc =
+            (l(u, temp; visc = viscosity + h) - l(u, temp; visc = viscosity - h)) / 2h
+        dloss_cond =
+            (l(u, temp; cond = conductivity + h) - l(u, temp; cond = conductivity - h)) / 2h
+        dloss_grav = (l(u, temp; grav = gravity + h) - l(u, temp; grav = gravity - h)) / 2h
         @test dot(gu, vu) ≈ dloss_u rtol = 1e-6
         @test dot(gtemp, vtemp) ≈ dloss_temp rtol = 1e-6
+        @test gvisc ≈ dloss_visc rtol = 1e-6
+        @test gcond ≈ dloss_cond rtol = 1e-6
+        @test ggrav ≈ dloss_grav rtol = 1e-6
     end
+end
+
+# https://github.com/agdestein/IncompressibleNavierStokes.jl/issues/179
+@testitem "Viscosity gradient through create_right_hand_side" begin
+    using Random
+    using Zygote
+    T = Float64
+    rng = Xoshiro(123)
+    n = 8
+    ax = range(T(0), T(2π), n + 1)
+    setup = Setup(;
+        x = (ax, ax),
+        boundary_conditions = (;
+            u = ((PeriodicBC(), PeriodicBC()), (PeriodicBC(), PeriodicBC())),
+        ),
+    )
+    psolver = psolver_spectral(setup)
+    rhs = create_right_hand_side(setup, psolver)
+    u = randn(rng, T, setup.N..., 2)
+    viscosity = T(0.01)
+    f(u, viscosity) = sum(abs2, rhs(u, (; viscosity), T(0)))
+    gu, gvisc = Zygote.gradient(f, u, viscosity)
+    @test any(!iszero, gu)
+    h = cbrt(eps(T))
+    fd = (f(u, viscosity + h) - f(u, viscosity - h)) / 2h
+    @test gvisc ≈ fd rtol = 1e-6
 end


### PR DESCRIPTION
Closes #179.

The `ChainRulesCore.rrule`s for `diffusion`, `convection_diffusion_temp`, and `applygravity` returned `NoTangent()` for their scalar coefficients (viscosity, conductivity, gravity), so `Zygote.gradient` silently returned `nothing` for them — as reported in #179 for the viscosity through `create_right_hand_side`.

Each of these terms is linear in its scalar coefficient, so the cotangent is just the inner product of the output cotangent with the operator evaluated at unit coefficient:

- `diffusion`: `viscositybar = dot(diffusion(u, setup, one(viscosity)), φ)`
- `convection_diffusion_temp`: evaluated at zero velocity and unit conductivity (the convective part vanishes with `u = 0`)
- `applygravity`: `gravitybar = dot(applygravity(temp, setup, gdir, one(gravity)), φbar)`

One extra forward kernel call in each pullback, no new adjoint kernels.

Not included, deliberately:
- `dissipation`: its pullback is entirely unimplemented (also w.r.t. `u`, which needs a hand-written adjoint of the `∇_coll` stencil) — separate work.
- Enzyme rules (`ext/EnzymeCoreExt.jl`) still treat the coefficients as `Const` — Zygote/ChainRules only for now.

Tests:
- `test_rrule` FD checks now cover the scalar coefficient tangents in 2D and 3D (removed the `⊢ NoTangent()` markers).
- The Boussinesq Zygote gradient test additionally checks viscosity/conductivity/gravity gradients against finite differences.
- New regression test item reproducing #179 through `create_right_hand_side` (periodic BCs, spectral pressure solver).

Full suite: 527 pass, 5 broken (pre-existing `@test_broken`), 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)