### PR TITLE
Fix stage times in LMWray3 for time-dependent boundary conditions

### DIFF
--- a/src/boundary_conditions.jl
+++ b/src/boundary_conditions.jl
@@ -5,11 +5,14 @@ abstract type AbstractBC end
 struct PeriodicBC <: AbstractBC end
 
 """
-Dirichlet boundary conditions for the velocity, where `u[1] = (x..., t) ->
-u1_BC` up to `u[d] = (x..., t) -> ud_BC`, where `d` is the dimension.
+Dirichlet boundary conditions for the velocity. The value `u` is one of:
 
-When `u` is `nothing`, then the boundary conditions are
-no slip boundary conditions, where all velocity components are zero.
+- `nothing` (default): no-slip boundary conditions, where all velocity
+  components are zero;
+- a tuple of `d` constants `(u1_BC, ..., ud_BC)`, one per velocity component,
+  where `d` is the dimension;
+- a function `(dim, x..., t) -> u_BC` returning the boundary value of velocity
+  component `dim` at the point `x...` and time `t`.
 """
 struct DirichletBC{U} <: AbstractBC
     "Boundary condition"

--- a/src/time_steppers/step_lmwray3.jl
+++ b/src/time_steppers/step_lmwray3.jl
@@ -52,11 +52,14 @@ function timestep!(
     #    | b1 b2 b3  ⋯ bn-1 an
     #
     # Note the definition of (ai)i.
-    # They are shifted to simplify the for-loop.
+    # Both the (ai)i and the stage times (ci)i are shifted to simplify the
+    # for-loop: iteration `i` produces the stage state at time `t + c[i] * Δt`
+    # (same convention as `runge_kutta_method`, which shifts via
+    # `c = [c[2:end]; 1]`). The unshifted stage times are 0, 8/15, 2/3.
     # TODO: Make generic by passing a, b, c as inputs
     a = T(8 / 15), T(5 / 12), T(3 / 4)
     b = T(1 / 4), T(0)
-    c = T(0), T(8 / 15), T(2 / 3)
+    c = T(8 / 15), T(2 / 3), T(1)
     nstage = length(a)
 
     for i = 1:nstage
@@ -80,9 +83,10 @@ function timestep!(
     # Full time step
     t = tstart + Δt
 
-    # This is redundant, but Neumann BC need to have _exact_ copies
-    # since we divide by an infinitely thin (eps(T)) volume width in the
-    # diffusion term
+    # The last stage already produced the state at t = tstart + Δt (c[nstage] = 1),
+    # so this re-application is redundant for the DOFs. We keep it because
+    # Neumann BC need to have _exact_ copies, since we divide by an infinitely
+    # thin (eps(T)) volume width in the diffusion term.
     apply_bc_u!(state.u, t, setup)
     dotemp && apply_bc_temp!(state.temp, t, setup)
 
@@ -112,11 +116,14 @@ function timestep(method::LMWray3, force, stepper, Δt; params = nothing)
     #    | b1 b2 b3  ⋯ bn-1 an
     #
     # Note the definition of (ai)i.
-    # They are shifted to simplify the for-loop.
+    # Both the (ai)i and the stage times (ci)i are shifted to simplify the
+    # for-loop: iteration `i` produces the stage state at time `t + c[i] * Δt`
+    # (same convention as `runge_kutta_method`, which shifts via
+    # `c = [c[2:end]; 1]`). The unshifted stage times are 0, 8/15, 2/3.
     # TODO: Make generic by passing a, b, c as inputs
     a = T(8 / 15), T(5 / 12), T(3 / 4)
     b = T(1 / 4), T(0)
-    c = T(0), T(8 / 15), T(2 / 3)
+    c = T(8 / 15), T(2 / 3), T(1)
     nstage = length(a)
 
     for i = 1:nstage
@@ -151,9 +158,8 @@ function timestep(method::LMWray3, force, stepper, Δt; params = nothing)
     # Full time step
     t = tstart + Δt
 
-    # This is redundant, but Neumann BC need to have _exact_ copies
-    # since we divide by an infinitely thin (eps(T)) volume width in the
-    # diffusion term
+    # The last stage already applied the boundary conditions at
+    # t = tstart + Δt (c[nstage] = 1), so no re-application is needed here.
 
     create_stepper(method; setup, psolver, state, t, n = n + 1)
 end

--- a/test/boundary_conditions.jl
+++ b/test/boundary_conditions.jl
@@ -1,0 +1,85 @@
+@testitem "Poiseuille flow with pressure outlet" begin
+    # Steady Poiseuille flow: parabolic Dirichlet inflow, no-slip walls,
+    # pressure outlet. After integrating to steady state, the volume flux
+    # must be conserved along the channel, the interior must be
+    # divergence-free, and the profile must match the analytic parabola.
+    uin(dim, x, y, t) = dim == 1 ? 6 * y * (1 - y) : zero(x)
+    boundary_conditions =
+        (; u = ((DirichletBC(uin), PressureBC()), (DirichletBC(), DirichletBC())))
+    setup = Setup(; x = (range(0.0, 4.0, 33), range(0.0, 1.0, 17)), boundary_conditions)
+    (; Iu, Ip, Δ, xu) = setup
+
+    # Start from the analytic profile and integrate to steady state
+    y = reshape(xu[1][2], 1, :)
+    u0 = vectorfield(setup)
+    u0[:, :, 1] .= 6 .* y .* (1 .- y)
+    u0 = apply_bc_u(u0, 0.0, setup)
+    state, _ = solve_unsteady(;
+        setup,
+        tlims = (0.0, 20.0),
+        start = (; u = u0),
+        Δt = 0.01,
+        params = (; viscosity = 0.05),
+    )
+
+    # Volume fluxes at the inlet, at interior stations, and at the outlet
+    # must all agree
+    jrange = Ip.indices[2]
+    flux(i) = sum(j -> state.u[i, j, 1] * Δ[2][j], jrange)
+    is = Iu[1].indices[1]
+    stations = [is[1] - 1; collect(is[1:8:end]); is[end]]
+    fluxes = flux.(stations)
+    @test maximum(fluxes) - minimum(fluxes) < 1e-8
+
+    # Divergence-free interior
+    @test maximum(abs, view(divergence(state.u, setup), Ip)) < 1e-10
+
+    # Parabolic profile at an interior station. The error is dominated by
+    # the truncation error of the diffusion stencil in the wall-adjacent
+    # half-cells (measured: 2.4e-3 relative at this resolution).
+    imid = is[length(is)÷2]
+    @test view(state.u, imid, jrange, 1) ≈ uin.(1, 2.0, xu[1][2][jrange], 0.0) rtol = 5e-3
+end
+
+@testitem "Time derivative of Dirichlet boundary conditions" begin
+    # With `dudt = true`, `apply_bc_u` fills the boundary values with the
+    # time derivative of the boundary conditions (approximated internally
+    # with a central finite difference in time).
+    uin(dim, x, y, t) = dim == 1 ? 1 + 0.5 * sinpi(2t) : zero(x)
+    boundary_conditions =
+        (; u = ((DirichletBC(uin), PressureBC()), (SymmetricBC(), SymmetricBC())))
+    setup = Setup(; x = (range(0.0, 4.0, 17), range(0.0, 1.0, 9)), boundary_conditions)
+    (; Iu, Ip) = setup
+    u = vectorfield(setup)
+    i1 = Iu[1].indices[1][1] - 1 # Inflow boundary layer of normal component
+    i2 = Iu[2].indices[1][1] - 1 # Inflow boundary layer of parallel component
+    for t in (0.13, 0.71)
+        dudt = apply_bc_u(u, t, setup; dudt = true)
+        # ∂uin/∂t = π cos(2πt)
+        @test all(≈(π * cospi(2t); rtol = 1e-6), view(dudt, i1, Ip.indices[2], 1))
+        @test all(iszero, view(dudt, i2, Ip.indices[2], 2))
+    end
+end
+
+@testitem "Uniform flow with lateral pressure boundaries" begin
+    # Uniform flow with constant Dirichlet inflow, and pressure boundaries
+    # at the outlet and on both lateral sides (the low side exercises the
+    # double-ghost-volume bookkeeping of PressureBC). The flow must be
+    # preserved to round-off.
+    boundary_conditions =
+        (; u = ((DirichletBC((1.0, 0.0)), PressureBC()), (PressureBC(), PressureBC())))
+    setup = Setup(; x = (range(0.0, 2.0, 33), range(0.0, 1.0, 17)), boundary_conditions)
+    u0 = vectorfield(setup)
+    u0[:, :, 1] .= 1.0
+    u0 = apply_bc_u(u0, 0.0, setup)
+    state, _ = solve_unsteady(;
+        setup,
+        tlims = (0.0, 0.2),
+        start = (; u = u0),
+        Δt = 0.005,
+        params = (; viscosity = 0.05),
+    )
+    @test maximum(abs, view(state.u, setup.Iu[1], 1) .- 1) < 1e-11
+    @test maximum(abs, view(state.u, setup.Iu[2], 2)) < 1e-11
+    @test maximum(abs, view(divergence(state.u, setup), setup.Ip)) < 1e-11
+end

--- a/test/timesteppers.jl
+++ b/test/timesteppers.jl
@@ -40,3 +40,52 @@
         @test stepper_inplace.state.temp ≈ stepper_outplace.state.temp
     end
 end
+
+@testitem "Stage times with time-dependent boundary conditions" begin
+    # Pulsating plug flow: uniform pulsating inflow u = (uin(t), 0) through a
+    # straight channel with symmetric walls. The exact solution is spatially
+    # uniform, u = (uin(t), 0) at all times, since the pressure projection
+    # forces the uniform interior to match the instantaneous inflow. Any
+    # method that applies boundary conditions and projection at the correct
+    # stage times reproduces this to machine precision, while incorrect stage
+    # times leave an O(Δt) velocity error and an O(Δt) divergence residual in
+    # the inflow cells.
+    uin(dim, x, y, t) = dim == 1 ? 1 + 0.5 * sinpi(2t) : zero(x)
+    boundary_conditions =
+        (; u = ((DirichletBC(uin), PressureBC()), (SymmetricBC(), SymmetricBC())))
+    setup = Setup(; x = (range(0.0, 4.0, 65), range(0.0, 1.0, 33)), boundary_conditions)
+    psolver = default_psolver(setup)
+    u0 = vectorfield(setup)
+    u0[:, :, 1] .= uin(1, 0.0, 0.0, 0.0)
+    u0 = apply_bc_u(u0, 0.0, setup)
+    Δt = 0.005
+    tend = 0.9
+    params = (; viscosity = 0.05)
+    uerror(u, t) = maximum(abs, view(u, setup.Iu[1], 1) .- uin(1, 0.0, 0.0, t))
+    diverror(u) = maximum(abs, view(divergence(u, setup), setup.Ip))
+    for method in [LMWray3(), RKMethods.RK44()]
+        state, _ = solve_unsteady(;
+            setup,
+            psolver,
+            tlims = (0.0, tend),
+            start = (; u = u0),
+            Δt,
+            method,
+            params,
+        )
+        @test uerror(state.u, tend) < 1e-10
+        @test diverror(state.u) < 1e-10
+    end
+
+    # The out-of-place code path of LMWray3 (not exercised by solve_unsteady)
+    let method = LMWray3()
+        stepper = create_stepper(method; setup, psolver, state = (; u = copy(u0)), t = 0.0)
+        nstep = round(Int, tend / Δt)
+        for _ = 1:nstep
+            stepper = timestep(method, navierstokes, stepper, Δt; params)
+        end
+        @test stepper.t ≈ tend
+        @test uerror(stepper.state.u, tend) < 1e-10
+        @test diverror(stepper.state.u) < 1e-10
+    end
+end


### PR DESCRIPTION
## The bug

An internal audit of time-dependent boundary-condition handling turned up a stage-time off-by-one in the default time stepper `LMWray3`.

The stage loop in `src/time_steppers/step_lmwray3.jl` follows the *shifted* tableau convention — iteration `i` produces the stage state at `t + c[i] * Δt` — the same convention as `runge_kutta_method` in `src/time_steppers/methods.jl`, which shifts via `c = [c[2:end]; 1]`. The `a` and `b` coefficients were shifted accordingly, but the hardcoded `c` was not: it read `(0, 8/15, 2/3)` instead of `(8/15, 2/3, 1)`, in both the in-place `timestep!` and out-of-place `timestep` variants.

## Consequences

`apply_bc_u!` and the pressure projection were applied at the *previous* stage's time. The final state of each step was projected with boundary values at `t + (2/3)Δt`, after which the boundaries were overwritten at `t + Δt` without re-projection. For time-dependent Dirichlet boundary conditions (or time-dependent forcing) this degrades the method to first order and leaves an O(Δt) divergence residual in the inflow cells. Steady boundary conditions and autonomous forcing are unaffected — which is why the existing test (periodic box, comparing in-place vs out-of-place, which shared the bug) never caught it.

## Discriminating test

Pulsating plug flow: uniform inflow `u = (1 + 0.5 sin(2πt), 0)` through a straight channel with symmetric walls and a pressure outlet. The exact solution is spatially uniform at all times, and any stepper that applies boundary conditions and projection at the correct stage times reproduces it to machine precision (the projection forces the uniform interior to match the instantaneous inflow at the last stage time, regardless of RK order).

Measured at Δt = 0.005, t_end = 0.9 (terminal velocity error, max interior divergence):

| | before | after |
|---|---|---|
| `LMWray3` in-place | 4.2e-3, 6.8e-2 | 2.2e-14, 5.5e-14 |
| `LMWray3` out-of-place | 4.2e-3, 4.6e-14 | 2.2e-14, 6.1e-14 |
| `RKMethods.RK44()` (reference) | 2.2e-14, 6.1e-14 | 2.2e-14, 6.1e-14 |

The velocity error matches the predicted `|u_in′| Δt / 3`.

## Changes

- Shift `c` to `(8/15, 2/3, 1)` in both `timestep!` and `timestep` for `LMWray3`; update the tableau comments to document the shifted convention. The post-loop `apply_bc_u!` is kept (Neumann BC still need exact ghost copies) with an updated comment.
- New test item "Stage times with time-dependent boundary conditions" (`test/timesteppers.jl`) covering `LMWray3` (both code paths) and `RK44` against the exact plug-flow solution.
- New `test/boundary_conditions.jl` with previously missing coverage:
  - steady Poiseuille flow with a pressure outlet: flux conservation along the channel (spread < 1e-8, measured ~2e-15), divergence-free interior, and profile vs the analytic parabola;
  - `apply_bc_u(u, t, setup; dudt = true)` fills inflow boundary values with the time derivative of the boundary condition;
  - uniform flow with pressure boundaries on the outlet and both lateral sides (exercises the low-side double-ghost-volume bookkeeping of `PressureBC`), preserved exactly.
- Corrected the `DirichletBC` docstring: it documented a tuple-of-functions form that the implementation does not support (throws a `MethodError`). The accepted forms are `nothing`, a tuple of `d` constants, or a single function `f(dim, x..., t)`.

Full test suite passes: 544 pass, 5 broken (pre-existing), 549 total.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gdif1Cu1pdCJENe2hNUaF1