### PR TITLE
Reference CUDA directly in CUDSS/AMGX extensions

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -27,8 +27,8 @@ EnzymeCore = "f151be2c-9106-41f4-ab19-57ee4f262869"
 Makie = "ee78f7c6-11fb-53f2-987a-cfe4a2b5a57a"
 
 [extensions]
-AMGXExt = ["AMGX"]
-CUDSSExt = ["CUDSS"]
+AMGXExt = ["AMGX", "CUDA"]
+CUDSSExt = ["CUDSS", "CUDA"]
 EnzymeCoreExt = ["EnzymeCore"]
 MakieExt = ["Makie"]
 

--- a/examples/DipolePOD.jl
+++ b/examples/DipolePOD.jl
@@ -15,8 +15,8 @@
 
 using Adapt
 using CairoMakie
-using CUDA
-using CUDSS
+## using CUDA
+## using CUDSS
 using JLD2
 using LinearAlgebra
 using ProgressMeter
@@ -70,13 +70,10 @@ end
 # Output directory (for saving plots and snapshots)
 output() = mkpath(joinpath(@__DIR__, "output/DipolePOD"))
 
-# If a CUDA-compatible GPU is available, use it. Otherwise, use CPU.
-getbackend() =
-    if CUDA.functional()
-        CUDABackend()
-    else
-        NS.KernelAbstractions.CPU()
-    end
+# Use the CPU by default. To run on a CUDA-compatible GPU, uncomment the
+# `using CUDA` and `using CUDSS` lines above and use the GPU definition below.
+getbackend() = NS.KernelAbstractions.CPU()
+## getbackend() = CUDA.functional() ? CUDABackend() : NS.KernelAbstractions.CPU()
 
 # Domain setup
 function getsetup()

--- a/ext/AMGXExt.jl
+++ b/ext/AMGXExt.jl
@@ -6,10 +6,11 @@ Introduces fast CG method for Poisson solver using AMGX.
 module AMGXExt
 
 using AMGX
+using CUDA
+using CUDA.CUSPARSE
 using IncompressibleNavierStokes
 using IncompressibleNavierStokes: PressureBC, laplacian_mat
 using SparseArrays
-using AMGX.CUDA
 
 function IncompressibleNavierStokes.amgx_setup()
     AMGX.initialize()

--- a/ext/CUDSSExt.jl
+++ b/ext/CUDSSExt.jl
@@ -7,8 +7,8 @@ This makes `psolver_direct` use a CUDSS decomposition for `CuArray`s.
 module CUDSSExt
 
 using CUDSS
-using CUDSS.CUDA
-using CUDSS.CUDA.CUSPARSE
+using CUDA
+using CUDA.CUSPARSE
 using IncompressibleNavierStokes
 using IncompressibleNavierStokes: PressureBC, laplacian_mat
 using SparseArrays


### PR DESCRIPTION
## Problem

The docs build emitted `UndefVarError: CUDA not defined in CUDSS`. **CUDSS 0.6.5** no longer exposes a `CUDA` binding inside its module namespace, so `using CUDSS.CUDA` in `CUDSSExt` fails at extension precompilation time whenever CUDSS and CUDA are both present in the environment (as they are in the docs Manifest). The error was non-fatal (precompile warning), so it did not cause the recent stable-docs deploy failure — that was a separate stale `stable` symlink on `gh-pages` — but it will bite any GPU user on current CUDSS.

`AMGXExt` used the same fragile pattern (`using AMGX.CUDA`), working only because AMGX 0.2 still re-exports CUDA.

## Fix

- `CUDA` is already a `[weakdeps]`, so reference it directly: `using CUDA` / `using CUDA.CUSPARSE` in both `CUDSSExt` and `AMGXExt`.
- Add `CUDA` as a co-trigger: `CUDSSExt = ["CUDSS", "CUDA"]`, `AMGXExt = ["AMGX", "CUDA"]`.
- Comment out `using CUDA` / `using CUDSS` in `examples/DipolePOD.jl` so it defaults to CPU (matching the other GPU examples' `## using CUDA, CUDSS` style), avoiding pulling GPU packages into the docs build unnecessarily.

## Notes

- Not runtime-verified locally (no GPU/CUDA on the dev machine); the extensions load only when their trigger packages are present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)